### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
 
 jobs:
   build:
@@ -34,7 +36,7 @@ jobs:
     - name: Convert libs
       run: node ./src/convert.mjs ./ts/built/local -o ./libs/index.d.ts
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libs
         path: ./libs


### PR DESCRIPTION
* upgrade deprecated `ctions/upload-artifact@v2` to v4
* add a trigger to manually run action




大佬们考不考虑加计划任务啊
